### PR TITLE
Update Vanilla.py

### DIFF
--- a/PokerRL/game/_/wrappers/Vanilla.py
+++ b/PokerRL/game/_/wrappers/Vanilla.py
@@ -25,7 +25,7 @@ class VanillaWrapper(Wrapper):
         self.env.print_obs(wrapped_obs)
 
     def get_current_obs(self, env_obs=None):
-        if env_obs in not None:
+        if env_obs is not None:
             return env_obs
         return self.env.get_current_obs()
 

--- a/PokerRL/game/_/wrappers/Vanilla.py
+++ b/PokerRL/game/_/wrappers/Vanilla.py
@@ -25,7 +25,7 @@ class VanillaWrapper(Wrapper):
         self.env.print_obs(wrapped_obs)
 
     def get_current_obs(self, env_obs=None):
-        if env_obs:
+        if env_obs in not None:
             return env_obs
         return self.env.get_current_obs()
 


### PR DESCRIPTION
env_obs is a Numpy array so its state is not defined if you check it that way.
Should be checked with "is not None".